### PR TITLE
Analytics: add PostHog pixel (production only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ Both `src/pages/posts/[...slug].astro` and `src/pages/rss.xml.js` already use th
 - The **`max-w-[1100px]` + `px-6` outer container** is the page rhythm. Keep new sections consistent with it.
 - The **eyebrow + h2 + lede** pattern at the top of every section. It's the design system's section header — reuse it, don't reinvent it.
 
+## PR conventions
+
+- **Never include a "Test plan" section in PR descriptions.** Summary only.
+
 ## When in doubt
 
 - Read [README.md](./README.md) for the user-facing contract.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -120,6 +120,18 @@ const fullTitle =
     <!-- Per-page structured data — see slot below for JSON-LD. -->
     <slot name="head" />
 
+    <!-- PostHog analytics — production only -->
+    {import.meta.env.PROD && (
+    <script is:inline>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="Mi Ri init Vi Gi Rr Wi Ji Bi capture calculateEventProperties tn register register_once register_for_session unregister unregister_for_session an getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync un identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty nn Xi createPersonProfile setInternalOrTestUser sn Hi cn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Ki debug Lr rn getPageViewId captureTraceFeedback captureTraceMetric Di".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_zru7uhDaodz9WpoS9nPKEKTPbQhQK6kXimNUdfR73TSP', {
+        api_host: 'https://us.i.posthog.com',
+        defaults: '2026-01-30',
+        person_profiles: 'identified_only',
+      })
+    </script>
+    )}
+
     <ClientRouter />
   </head>
   <body class={bodyClass}>


### PR DESCRIPTION
## Summary
- Add the PostHog HTML snippet to `src/layouts/Layout.astro` so every page loads it.
- Gate on `import.meta.env.PROD` — absent during `astro dev`, rendered only in production builds.
- Document the no-test-plan PR convention in `AGENTS.md`.