### PR TITLE
Posts: guitar essay + post-page artwork + UTC dates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,25 @@ const x: number = 1;
 
 Both light and dark themes are emitted as CSS variables; the active one is selected by `html.dark` (see `.astro-code` rules in `src/styles/global.css`).
 
+**Dates render in UTC.** `formatDate` in `src/lib/utils.ts` forces `timeZone: "UTC"`. A frontmatter `date: "2026-05-17"` parses as UTC midnight; without the override it renders as May 16 in any negative-offset locale. Keep `timeZone: "UTC"` if you touch that helper.
+
+#### Embedding YouTube / Vimeo
+
+Wrap the iframe in `<div class="video-embed">…</div>`. The `.video-embed` rule in `global.css` makes it a 16:9 fluid container with rounded corners. Example: `src/content/posts/why-road-bike-racing-is-my-favorite-sport.md`.
+
+#### Giving a post artwork (home-page tile + post-page header)
+
+Posts don't carry artwork directly — instead, **pair the post with a project entry** whose `href` points back to the post. The post-page template (`src/pages/posts/[...slug].astro`) looks up that match and renders the project's `<ProjectArt>` at the top of the post; the same artwork shows on the home-page gallery wall via the projects loop.
+
+Steps:
+1. Add a component in `src/components/art/` (e.g. `GuitarLyricArt.astro`). Position it `absolute; inset: 0;` so it fills the parent canvas.
+2. Register it in `src/components/ProjectArt.astro` (import + add a `case` to the dispatcher).
+3. Create the paired project entry in `src/content/projects/<slug>.md` with `badge: "Writing"`, `meta: "Essay"`, `href: "/posts/<slug>"`, and `artwork: "<key>"`. The road-bike post (`road-bike-racing.md`) and the guitar post (`learning-guitar-at-47.md`) are the working examples.
+
+Gotchas:
+- The post-page header canvas is **16:10 landscape** with `object-fit: cover`. Portrait artwork (the lino-cut bike is 1122×1402) gets cropped. If un-cropped display matters, give the art component an `inline-block`-style natural aspect override (RoadBikeArt does this for the gallery via `:global .frame-canvas:has(.rb-art)`).
+- Lyric/text art should use container queries (`container-type: inline-size` + `clamp(min, Xcqi, max)` font size) so it stays legible across the wall's sm/md/lg/xl sizes without per-size overrides.
+
 ### A project
 
 Create `src/content/projects/<slug>.md`:

--- a/src/components/ProjectArt.astro
+++ b/src/components/ProjectArt.astro
@@ -12,6 +12,7 @@ import LiveViewJSPoster from "./art/LiveViewJSPoster.astro";
 import HotDogJSArt from "./art/HotDogJSArt.astro";
 import GstateArt from "./art/GstateArt.astro";
 import RoadBikeArt from "./art/RoadBikeArt.astro";
+import GuitarLyricArt from "./art/GuitarLyricArt.astro";
 
 interface Props {
   artwork?: string;
@@ -40,6 +41,8 @@ const thumbBgClass: Record<string, string> = {
     <GstateArt />
   ) : artwork === "roadbike" ? (
     <RoadBikeArt />
+  ) : artwork === "guitar-lyric" ? (
+    <GuitarLyricArt />
   ) : (
     <div class={`fallback-canvas ${thumbBgClass[thumbColor]}`}>
       <span class="fallback-num">{String(index + 1).padStart(2, "0")}</span>

--- a/src/components/art/GuitarLyricArt.astro
+++ b/src/components/art/GuitarLyricArt.astro
@@ -1,0 +1,35 @@
+---
+// Vintage-typewriter lyric card for the "Learning Guitar at 47" post.
+// Three lines on a stark black ground, set in Special Elite to evoke
+// a typewritten page. Fills its parent .frame-canvas.
+---
+
+<div class="lyric-art">
+  <p>love of mine</p>
+  <p>someday</p>
+  <p>you will die</p>
+</div>
+
+<style>
+  .lyric-art {
+    position: absolute;
+    inset: 0;
+    background: #000;
+    color: #ede6d3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6em;
+    font-family: "Special Elite", "Courier New", ui-monospace, monospace;
+    /* Scales with the frame so the type stays readable across wall
+       sizes (sm/md/lg/xl) without per-size overrides. */
+    font-size: clamp(11px, 1.6cqi, 22px);
+    letter-spacing: 0.08em;
+    text-shadow: 0 0 1px rgba(237, 230, 211, 0.4);
+    container-type: inline-size;
+  }
+  .lyric-art p {
+    margin: 0;
+  }
+</style>

--- a/src/content/posts/learning-guitar-at-47.md
+++ b/src/content/posts/learning-guitar-at-47.md
@@ -1,0 +1,56 @@
+---
+title: "Learning to Play Guitar at 47"
+description: "Why I started playing and why you should"
+date: "2026-05-17"
+tags: ["music", "essay"]
+---
+
+I played my first guitar recital on May 17th, 2026 at age 47.  I sang and finger-picked a song called "I will follow you into the dark" by Death Cab for Cutie. It went off pretty well considering, I'd never practiced singing into a microphone with the guitar plugged into an amp before.
+
+I was the oldest "student" there by at least 30 years, mostly closer to 35 years.  It is kind of weird, if you think about it, that 99% of people learning to play are kids.  Ironically, a lot of kids give up on learning because they're being forced to go.
+
+## No music lessons as a kid
+
+I always wanted to be able to play an instrument but never took lessons as a kid.  None of my siblings did and I don't recall any of my friends taking lessons either.  As one of four kids in a working class family with working class friends and neighbors, I just don't think it was even a consideration.
+
+## I did (and continued) to sing
+
+I did always love to sing though.  I remember singing a lot with my dad.  We listened to lots of radio.  Most of the music was from the 50s-80s so like classic "oldies" and a lot of "smooth", love song type stuff.  Some of my favorite memories are working along side my dad on some project with the radio turned up with us belting out the words.
+
+## Deciphering notes seemed magical
+
+Later, as a teenager and early adult, I was always so impressed by people who played instruments and read music. It seemed magical. Some of my highschool friends had electric guitars they played some songs and I did some singing but I never knew how to decipher the notes on the sheet music.  I think back and wonder why I didn't ask someone to just explain it to me.
+
+## Bad timing last attempt at lessons
+
+Fast forward, 12 years after college about a month before my 12yo daughter was born, my wife got me piano lessons for my birthday! We had inherited her mom's piano and I mentioned to her that I always wanted to learn how to play.  It was a great several weeks of lessons.  I FINALLY learned how to read the notes, which now seems (at least logically) straight forward. Connecting the reading to ones fingers is another story.  Unfortunately, a newborn is not conducive to practicing piano (or much else for that matter), so I stopped.
+
+## 11 years later
+
+As parents know, the days are long and the years are short. My second daughter was taking piano lessons and, as kids do, decided she wasn't particularly interested in continuing. As she was quitting, I thought I'd really like to learn so decided I would give it a shot. (Yes, part of my motivation was to show her that all the practice would eventually grow into enjoyment. Typical parental thinking!)
+
+Part of my calculation was also that, from a life expectancy standpoint, I should still have another 35ish years of living and that is still a lot of years to either be disappointed that I don't play an instrument or excited that I do.
+
+## Progress was/is slow
+
+Honestly, the first few months were a slog and I felt like I wasn't making much progress. I'd go in for my lesson, practice a bit througout the week, and then go back and feel like I wasn't really better. I wanted to quit! (I get why the kids want to now!) But, I kept at it.  Started trying to get 15 minutes a day in.  Would strum before heading up to bed.  I'd try to play while the family watched some TV (and was eventually banished to my office).
+
+Every once in a while I'd notice that making a chord shape was slightly better and faster.  I'd be able to play a chord that I couldn't before.  Or I'd be able to transition between chords slightly faster.  It was a lot of sucking and a lot of terrible sounds and out of rhythm strumming.  Frankly it still is mostly suck but also it is good enough that I've progressed to this-is-kind-of-fun stage.
+
+## I recommend sucking at an instrument
+
+It is good to be bad at stuff. Being bad at stuff takes us out of our comfort zone and asks us what we're going to do about it. Are we going to give up and regret it or are we going to suffer through the effort to get to some viable level?
+
+I've got a lifetime left to get better but I am excited to be able to read music, play some chords, strum along, and belt out some songs that are meaningful to me.
+
+## Here I am playing and singing
+
+<div class="video-embed">
+  <iframe
+    src="https://www.youtube.com/embed/eJznHHaRP-E"
+    title="YouTube video"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>

--- a/src/content/projects/learning-guitar-at-47.md
+++ b/src/content/projects/learning-guitar-at-47.md
@@ -1,0 +1,16 @@
+---
+title: "Learning to Play Guitar at 47"
+description: "On starting an instrument mid-life and the value of being bad at things."
+year: "2026"
+meta: "Essay"
+badge: "Writing"
+badgeColor: "plum"
+thumbColor: "plum"
+order: 5
+href: "/posts/learning-guitar-at-47"
+artwork: "guitar-lyric"
+gallerySize: "md"
+frameStyle: "bone"
+---
+
+A short note on picking up guitar at 47.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -73,7 +73,7 @@ const fullTitle =
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;0,900;1,400;1,700;1,900&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=JetBrains+Mono:wght@400;500&family=Sixtyfour&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;0,900;1,400;1,700;1,900&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=JetBrains+Mono:wght@400;500&family=Sixtyfour&family=Special+Elite&display=swap"
       rel="stylesheet"
     />
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,12 @@
 export function formatDate(date: Date) {
+  // Format in UTC — frontmatter dates like "2026-05-17" parse as UTC
+  // midnight, so any negative-offset locale (US) would render them as
+  // the previous day.
   return Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   }).format(date);
 }
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import ProjectArt from "../../components/ProjectArt.astro";
 import { formatDate } from "../../lib/utils";
 import { AUTHOR_NAME, SITE_TITLE, SITE_URL } from "../../consts";
 
@@ -15,6 +16,15 @@ type Props = CollectionEntry<"posts">;
 
 const post = Astro.props;
 const { Content } = await render(post);
+
+// Find the matching project tile (if any) so we can reuse its
+// artwork at the top of the post. Projects link out to posts via
+// `href: "/posts/<slug>"` — see road-bike-racing.md, learning-guitar-at-47.md.
+const projects = await getCollection("projects");
+const postPath = `/posts/${post.id}`;
+const projectMatch = projects.find(
+  (p) => p.data.href === postPath || p.data.href === `${postPath}/`,
+);
 
 const postUrl = new URL(`/posts/${post.id}`, SITE_URL).toString();
 const ogUrl = new URL(`/og/posts/${post.id}.png`, SITE_URL).toString();
@@ -95,6 +105,20 @@ const articleLD = {
       )
     }
 
+    {
+      projectMatch && (
+        <figure class="post-art">
+          <div class="post-art-canvas">
+            <ProjectArt
+              artwork={projectMatch.data.artwork}
+              index={0}
+              thumbColor={projectMatch.data.thumbColor}
+            />
+          </div>
+        </figure>
+      )
+    }
+
     <hr class="my-8 border-0 border-t border-dashed border-line-soft" />
 
     <article>
@@ -102,3 +126,23 @@ const articleLD = {
     </article>
   </section>
 </Layout>
+
+<style>
+  /* Headline artwork echoing the home-page gallery tile. The canvas
+     hosts the same <ProjectArt> component, so artwork imagery stays
+     centralized in src/components/art/. Aspect ratio matches a
+     wide-landscape tile so lyric/text art and photographic art both
+     read well at the top of a post. */
+  .post-art {
+    margin: 0 0 1rem;
+  }
+  .post-art-canvas {
+    position: relative;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+    border-radius: 10px;
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45),
+      0 8px 22px -14px rgba(0, 0, 0, 0.35);
+  }
+</style>


### PR DESCRIPTION
## Summary
- New post **Learning to Play Guitar at 47** with a paired project tile (`learning-guitar-at-47.md` in both `posts/` and `projects/`).
- Vintage-typewriter lyric card (`GuitarLyricArt.astro`, Special Elite from Google Fonts) used as the artwork on the home-page gallery and at the top of the post page.
- Post-page template now looks up the matching project entry (by `href`) and renders its `<ProjectArt>` at the top of every post — works for the existing road-bike essay too.
- `formatDate` forced to UTC so `date: "2026-05-17"` no longer renders as May 16 in negative-offset locales.
- AGENTS.md gains a "Giving a post artwork" section, plus notes on the `.video-embed` wrapper and the UTC date rule.